### PR TITLE
Use correct dates in pre-notification emails (or: do not overwrite email configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ FD Tone Notify will automatically create a sample configuration file and blank `
 [Configuration](#Configuration) and [Environment Variables and Secrets](#Environment-Variables-and-Secrets) sections below. 
 
 #### How do I know what to enter for the tones?
-If you don't know the tones for the department/station you want to monitor run FD Tone Notify with the `--tone-detector` option.
+If you don't know the tones for the department/station you want to monitor run FD Tone Notify with the `--all-tone-detector` option.
 
-     fd-tone-notify.exe --tone-detector --web-server
+     fd-tone-notify.exe --all-tone-detector --web-server
      
 In this mode FD Tone Notify **WILL NOT** send notifications. Instead it will detect any multi-tones and print the results to console. 
 For example:
@@ -77,9 +77,9 @@ For example:
 
 This indicates that a two-tone dispatch was detected with tones 919Hz, 2940Hz. Enter `tones: [919, 2940]` to detect this department.
 
-:information_source: The `--tone-detector` option cannot detect single tones. It will only print results for multi-tone matches.
+:information_source: The `--all-tone-detector` option cannot detect single tones. It will only print results for multi-tone matches.
 
-:bulb: You can run FD Tone Notify in `--tone-detector` mode and normal "notification" mode at the same time. This is recommended
+:bulb: You can run FD Tone Notify in `--all-tone-detector` mode and normal "notification" mode at the same time. This is recommended
 when you are building out and fine tuning your configuration.
     
 #### Running FD Tone Notify and Using the Web Monitor for Live Streaming Audio

--- a/obj/NotificationParams.js
+++ b/obj/NotificationParams.js
@@ -40,12 +40,14 @@ class NotificationParams{
 
     getEmails(prePostType){
         const emails = this.__getNotificationOptions({prePostType, notificationKey: "emails"});
-        emails.map(email => {
-                email.text = email.text.replace('%d', this.dateString);
-                email.subject = email.subject.replace('%d', this.dateString);
-                return email;
+        const updatedEmails = emails.map(email => {
+                // Make a shallow copy of the email objects so we do not modify them
+                let emailCopy = Object.assign({}, email);
+                emailCopy.text = email.text.replace('%d', this.dateString);
+                emailCopy.subject = email.subject.replace('%d', this.dateString);
+                return emailCopy;
             });
-        return emails;
+        return updatedEmails;
     }
 
     getWebhooks(prePostType){

--- a/test/obj/NotificationParams.test.js
+++ b/test/obj/NotificationParams.test.js
@@ -30,7 +30,7 @@ const DEFAULT_PARAMS = {
 };
 
 describe("NotificationParams", function() {
-    it("should be able build", async function() {
+    it("should instantiate correctly", async function() {
         const notificationParams = new NotificationParams(DEFAULT_PARAMS);
         expect(notificationParams).instanceOf(NotificationParams);
         expect(notificationParams.detector).deep.equals(DEFAULT_PARAMS.detector);
@@ -96,6 +96,21 @@ describe("NotificationParams", function() {
             expect(emails).to.have.lengthOf(1);
             expect(emails[0].text).to.have.string("August 1st 2022, 0:00:00");
             expect(emails[0].subject).to.have.string("August 1st 2022, 0:00:00");
+        });
+
+        it("should not modify the original email objects", function() {
+            const preEmail = {
+                text: "PRE Text %d",
+                subject: "PRE Subject %d",
+            }
+            newParams = deep_copy(DEFAULT_PARAMS);
+            newParams.notifications.preRecording.emails.push(preEmail);
+
+            const notificationParams = new NotificationParams(newParams);
+
+            var emails = notificationParams.getEmails('PRE');
+            expect(preEmail.text).to.have.string("%d");
+            expect(preEmail.subject).to.have.string("%d");
         });
     });
 });

--- a/test/obj/NotificationParams.test.js
+++ b/test/obj/NotificationParams.test.js
@@ -1,0 +1,105 @@
+require('dotenv').config();
+const expect  = require("chai").expect;
+const {NotificationParams, MATCH_STATES} = require('../../obj/NotificationParams');
+const { TonesDetector } = require('../../obj/TonesDetector');
+
+const TONES_DETECTOR = new TonesDetector({
+    name: "Test",
+    tones: [1000, 1300],
+    tolerancePercent: 0.02,
+    matchThreshold: 8
+});
+
+const TIMESTAMP = 1659337200000; // Mon Aug 01 2022 07:00:00 GMT+0000
+const NOTIFICATIONS = {
+    preRecording: {
+        emails: []
+    },
+    postRecording: {
+        emails: []
+    }
+}
+
+const DEFAULT_PARAMS = {
+    detector: TONES_DETECTOR,
+    timestamp: TIMESTAMP,
+    filename: TIMESTAMP + '.wav',
+    matchAverages: [1, 2, 3],
+    notifications: NOTIFICATIONS,
+    message: 'This is a test.'
+};
+
+describe("NotificationParams", function() {
+    it("should be able build", async function() {
+        const notificationParams = new NotificationParams(DEFAULT_PARAMS);
+        expect(notificationParams).instanceOf(NotificationParams);
+        expect(notificationParams.detector).deep.equals(DEFAULT_PARAMS.detector);
+        expect(notificationParams.timestamp).equals(DEFAULT_PARAMS.timestamp);
+        expect(notificationParams.matchAverages).deep.equals(DEFAULT_PARAMS.matchAverages);
+        expect(notificationParams.notifications).deep.equals(DEFAULT_PARAMS.notifications);
+        expect(notificationParams.filename).equals(DEFAULT_PARAMS.filename);
+        expect(notificationParams.message).equals(DEFAULT_PARAMS.message);
+    });
+
+    describe("#getEmails", function() {
+        it("should return an empty list if there are no emails", function(){
+            const notificationParams = new NotificationParams(DEFAULT_PARAMS);
+            expect(notificationParams.getEmails('PRE')).deep.equals([])
+            expect(notificationParams.getEmails('POST')).deep.equals([])
+        });
+
+        it("should return the correct emails", function() {
+            const preEmail = {
+                text: "PRE Text",
+                subject: "PRE Subject",
+            }
+            const postEmail = {
+                text: "POST Text",
+                subject: "POST Subject"
+            }
+
+            newParams = deep_copy(DEFAULT_PARAMS);
+            newParams.notifications.preRecording.emails.push(preEmail);
+            newParams.notifications.postRecording.emails.push(postEmail);
+
+            const notificationParams = new NotificationParams(newParams);
+
+            var emails = notificationParams.getEmails('PRE');
+            expect(emails).deep.equals([preEmail]);
+
+            var emails = notificationParams.getEmails('POST');
+            expect(emails).deep.equals([postEmail])
+        });
+
+        it("should insert timestamps", function() {
+            const preEmail = {
+                text: "PRE Text %d",
+                subject: "PRE Subject %d",
+            }
+            const postEmail = {
+                text: "POST Text %d",
+                subject: "POST Subject %d"
+            }
+
+            newParams = deep_copy(DEFAULT_PARAMS);
+            newParams.notifications.preRecording.emails.push(deep_copy(preEmail));
+            newParams.notifications.postRecording.emails.push(deep_copy(postEmail));
+
+            const notificationParams = new NotificationParams(newParams);
+
+            var emails = notificationParams.getEmails('PRE');
+            expect(emails).to.have.lengthOf(1);
+            expect(emails[0].text).to.have.string("August 1st 2022, 0:00:00");
+            expect(emails[0].subject).to.have.string("August 1st 2022, 0:00:00");
+
+            var emails = notificationParams.getEmails('POST');
+            expect(emails).to.have.lengthOf(1);
+            expect(emails[0].text).to.have.string("August 1st 2022, 0:00:00");
+            expect(emails[0].subject).to.have.string("August 1st 2022, 0:00:00");
+        });
+    });
+});
+
+function deep_copy(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}

--- a/test/obj/NotificationParams.test.js
+++ b/test/obj/NotificationParams.test.js
@@ -109,6 +109,10 @@ describe("NotificationParams", function() {
             const notificationParams = new NotificationParams(newParams);
 
             var emails = notificationParams.getEmails('PRE');
+            expect(emails).to.have.lengthOf(1);
+            expect(emails[0].text).to.not.have.string("%d");
+            expect(emails[0].subject).to.not.have.string("%d");
+
             expect(preEmail.text).to.have.string("%d");
             expect(preEmail.subject).to.have.string("%d");
         });


### PR DESCRIPTION
Use correct dates in pre-notification emails (or: do not overwrite email configuration)

# Description
This PR fixes a bug where pre-notification emails contained incorrect timestamps in the subject and/or body text. Tests are included.

Additionally, a minor documentation fix is made to the README.

# Motivation
In my current configuration, I am sending both pre- and post-notification emails for tone detection events. In both cases, my email texts and subjects contain `%d` so that they include the date of the tone detection event.

What I noticed is that the pre-notification emails had the incorrect dates. More precisely, every pre-notification email after the first one had the timestamp of the very first tone detection event.

This means that if you started fd-tone-notify and detected tones three different times, the pre-notification emails would all have the timestamp of the first event. The post-notification emails were fine.

After a lot of debug logging (not included) I noticed that in `NotificationParams.getEmails`, `emails.text` might be, for example, `Tones Detected %d` the first time a pre-notification email was sent. On subsequent events, however, `emails.text` was `Tones Detected August 1st 2022, 0:00:00` or whatever the time of the first event was. This caused the `emails.text.replace("%d", this.dateString)` to effectively be a no-op.

# Explanation of changes
`NotificationParams.getEmails` now makes a shallow copy of the email objects before modifying the text/subject properties with timestamps. I've also provided tests!

P.S. - Thanks for creating fd-tone-notify and making it open source. It's extremely helpful and I really enjoy it a lot!