### PR TITLE
Fix thread leaks (fixes #13)

### DIFF
--- a/service/RecordingThread.js
+++ b/service/RecordingThread.js
@@ -20,10 +20,11 @@ class RecordingThread{
 
     __initThread(){
         if(this.__useAltRecording) {
-            log.silly('Initializing Alternative Recording Thread (Fork)')
+            log.debug('Using a new process for recording');
             this.__startedForkedThread();
         }
         else{ //Use Alt
+            log.debug('Using a new thread for recording');
             this.__startWorkerThread();
         }
     }

--- a/service/RecordingThread.js
+++ b/service/RecordingThread.js
@@ -33,8 +33,7 @@ class RecordingThread{
         this._recordingWorker.on("message", incoming => log.debug(`Message from Recording Worker ${this.threadId}: ${incoming}`));
         this._recordingWorker.on("error", code => new Error(`Recording Worker ${this.threadId} error with exit code ${code}`));
         this._recordingWorker.on("exit", code => {
-                log.debug(`Worker ${this.threadId} stopped with exit code ${code}. Restarting`);
-                this.__initThread();
+                log.debug(`Worker thread ${this.threadId} stopped with exit code ${code}.`);
             }
         );
     }
@@ -45,8 +44,7 @@ class RecordingThread{
         this._child.stdout.on("data", data => console.log(data.toString().replace(/(\r\n|\n|\r)/gm, "")));
         this._child.on("error", code => new Error(`Recording Worker ${this.threadId} error with exit code ${code}`));
         this._child.on("exit", code => {
-                log.debug(`Worker ${this.threadId} stopped with exit code ${code}. Restarting`);
-                this.__initThread();
+                log.debug(`Worker process ${this.threadId} stopped with exit code ${code}.`);
             }
         );
     }


### PR DESCRIPTION
This PR fixes the thread/process reported in #13. 

# Summary
In short, in `RecordingThread`, both `__startWorkerThread` and `__startedForkedThread` register callbacks that restart threads that exit, even if successful (exit code == 0). These threads and processes are not reused, however, and result in a new thread or process being created every time there is a `toneDetected` event. Please see #13 for a more detailed write-up.

# Solution
This PR fixes this issue by not restarting threads or processes when they exit. This means that once the thread/process is done doing work, it is destroyed. This has the side-effect that when processes exit with an error (exit code != 0) they will not retry; however, this seems preferable to thrashing jobs that will continue to fail (IMHO).

# Testing
1. Start a fresh instance of fd-tone-notify using the `main` branch with `node --trace-warnings index.js --debug`.
2. Inspect how many threads or processes exist with `pgrep --lightweight node | wc -l`. In my environment, there are 12.
3. Trigger a tone detection event however you normally do this (I play expected tones into my raspberry pi's USB sound card's mic jack).
4. Repeat step 2; in the `main` branch, you will see that there are now 13.
5. Repeat steps 2 to 4 and you will see that the thread or process count increases by one each time.
6. Checkout the branch in this PR and repeat steps 1 through 5. Instead of an increasing thread or process count, you will see that the number remains constant.

## Test environment
My test environment is as follows:

```
$ uname -a
Linux raspberrypi 5.10.103-v7l+ #1529 SMP Tue Mar 8 12:24:00 GMT 2022 armv7l GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID: Raspbian
Description:    Raspbian GNU/Linux 10 (buster)
Release:        10
Codename:       buster
```

_Note:_ Despite the ARM architecture, RecordingThreads are using actual threads (not processes) in my environment.